### PR TITLE
Fix live video playback

### DIFF
--- a/youtube-play/LinkResolver.cs
+++ b/youtube-play/LinkResolver.cs
@@ -89,7 +89,7 @@ namespace youtube_play
                             Extension = x["ext"].ToString(),
                             Width = x.Value<int?>("width"),
                             Height = x.Value<int?>("height"),
-                            Note = x["format_note"].ToString(),
+                            Note = x["format_note"]?.ToString(),
                             Bitrate = x.Value<float?>("abr") ?? x.Value<float?>("tbr"),
                             Url = x["url"].ToString()
                         }


### PR DESCRIPTION
`format_note` does not exist in the case of a live stream.